### PR TITLE
Add per-variable CIF panel mode to cifplot

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -303,10 +303,36 @@ For the initial illustration, unadjusted analysis focusing on cumulative inciden
 
 ```{r example1-1, warning=FALSE, message=FALSE}
 data(diabetes.complications)
-cifplot(Event(t,epsilon) ~ fruitq1, data=diabetes.complications, outcome.type="COMPETING-RISK", 
-        addConfidenceInterval=TRUE, addCensorMark=FALSE, addCompetingRiskMark=FALSE, 
-        label.y="CIF of diabetic retinopathy", label.x="Years from registration", 
+cifplot(Event(t,epsilon) ~ fruitq1, data=diabetes.complications, outcome.type="COMPETING-RISK",
+        addConfidenceInterval=TRUE, addCensorMark=FALSE, addCompetingRiskMark=FALSE,
+        label.y="CIF of diabetic retinopathy", label.x="Years from registration",
         label.strata=c("High intake","Low intake"))
+```
+
+To visualize each covariate separately when multiple strata are supplied, set `printEachVar = TRUE`.
+Each variable on the right-hand side is plotted in its own panel, and the layout can be
+controlled with `rows.columns.panel`. The example below contrasts cumulative incidence functions
+for sex and fruit intake side-by-side. When using numeric variables for stratification, discretize
+them beforehand with `cut()` or `factor()`.
+
+```{r example1-1a, warning=FALSE, message=FALSE}
+cifplot(
+  Event(t, epsilon) ~ sex + fruitq1,
+  data = diabetes.complications,
+  outcome.type = "COMPETING-RISK",
+  code.event1 = 1, code.event2 = 2, code.censoring = 0,
+  printEachVar = TRUE,
+  rows.columns.panel = c(1, 2),
+  order.strata = list(
+    sex     = c("Female", "Male"),
+    fruitq1 = c("Low", "High")
+  ),
+  label.strata = list(
+    sex     = c("Female", "Male"),
+    fruitq1 = c("Low intake", "High")
+  ),
+  limits.x = c(0, 10)
+)
 ```
 
 In the next figure, censoring marks are added along each curve (`addCensorMark = TRUE`) to indicate individuals who were censored before experiencing any event. These marks visualize the timing and frequency of censoring, allowing a clearer understanding of loss-to-censoring patterns over follow-up. Here usage of functions are different from the code above. The survfit object `output1` initially is generated using `cifcurve()` with `outcome.type="COMPETING-RISK"` by calculating Aalen–Johansen estimator stratified by fruitq1. Then, `cifplot()` is used to generate the figure. 
@@ -314,8 +340,8 @@ In the next figure, censoring marks are added along each curve (`addCensorMark =
 ```{r example1-2, warning=FALSE, message=FALSE}
 output1 <- cifcurve(Event(t,epsilon) ~ fruitq1, data=diabetes.complications, 
 outcome.type="COMPETING-RISK")
-cifplot(output1, addConfidenceInterval=FALSE, addCensorMark=TRUE, addCompetingRiskMark=FALSE, 
-        label.y="CIF of diabetic retinopathy", label.x="Years from registration", 
+cifplot(output1, addConfidenceInterval=FALSE, addCensorMark=TRUE, addCompetingRiskMark=FALSE,
+        label.y="CIF of diabetic retinopathy", label.x="Years from registration",
         label.strata=c("High intake","Low intake"))
 ```
 

--- a/README.md
+++ b/README.md
@@ -385,13 +385,40 @@ uncertainty of estimated probabilities across exposure levels.
 
 ``` r
 data(diabetes.complications)
-cifplot(Event(t,epsilon) ~ fruitq1, data=diabetes.complications, outcome.type="COMPETING-RISK", 
-        addConfidenceInterval=TRUE, addCensorMark=FALSE, addCompetingRiskMark=FALSE, 
-        label.y="CIF of diabetic retinopathy", label.x="Years from registration", 
+cifplot(Event(t,epsilon) ~ fruitq1, data=diabetes.complications, outcome.type="COMPETING-RISK",
+        addConfidenceInterval=TRUE, addCensorMark=FALSE, addCompetingRiskMark=FALSE,
+        label.y="CIF of diabetic retinopathy", label.x="Years from registration",
         label.strata=c("High intake","Low intake"))
 ```
 
 <img src="man/figures/README-example1-1-1.png" width="100%" />
+
+To visualize each covariate separately when multiple strata are supplied, set
+`printEachVar = TRUE`. Each variable on the right-hand side is plotted in its own
+panel, and the layout can be controlled with `rows.columns.panel`. The example
+below contrasts cumulative incidence functions for sex and fruit intake
+side-by-side. When using numeric variables for stratification, discretize them
+beforehand with `cut()` or `factor()`.
+
+``` r
+cifplot(
+  Event(t, epsilon) ~ sex + fruitq1,
+  data = diabetes.complications,
+  outcome.type = "COMPETING-RISK",
+  code.event1 = 1, code.event2 = 2, code.censoring = 0,
+  printEachVar = TRUE,
+  rows.columns.panel = c(1, 2),
+  order.strata = list(
+    sex     = c("Female", "Male"),
+    fruitq1 = c("Low", "High")
+  ),
+  label.strata = list(
+    sex     = c("Female", "Male"),
+    fruitq1 = c("Low intake", "High")
+  ),
+  limits.x = c(0, 10)
+)
+```
 
 In the next figure, censoring marks are added along each curve
 (`addCensorMark = TRUE`) to indicate individuals who were censored

--- a/man/cifplot.Rd
+++ b/man/cifplot.Rd
@@ -6,12 +6,12 @@
 censoring, competing risks and intermediate events}
 \usage{
 cifplot(
-  x,
+  formula,
   data = NULL,
   weights = NULL,
   subset.condition = NULL,
   na.action = na.omit,
-  outcome.type = "SURVIVAL",
+  outcome.type = c("COMPETING-RISK", "SURVIVAL"),
   code.event1 = 1,
   code.event2 = 2,
   code.censoring = 0,
@@ -53,11 +53,14 @@ cifplot(
   width.ggsave = 6,
   height.ggsave = 6,
   dpi.ggsave = 300,
+  printEachVar = FALSE,
+  rows.columns.panel = NULL,
+  order.strata = NULL,
   ...
 )
 }
 \arguments{
-\item{x}{A model formula or a survfit object.}
+\item{formula}{A model formula or a survfit object.}
 
 \item{data}{A data frame containing variables in \code{formula}.}
 
@@ -104,7 +107,8 @@ Ignored for non-competing-risk outcomes.}
 
 \item{label.y}{Character y-axis labels (default internally set to \code{"Survival"} or \code{"Cumulative incidence"}).}
 
-\item{label.strata}{Character vector of labels for strata.}
+\item{label.strata}{Character vector of labels for strata. When \code{printEachVar = TRUE}, you may
+also supply a named list \code{list(var = c("L1","L2", ...))}.}
 
 \item{limits.x}{Numeric length-2 vectors for axis limits. If NULL it is internally set to \code{c(0,max(out_readSurv$t))}.}
 
@@ -165,10 +169,26 @@ It calls geom_point() (default \code{TRUE}).}
 
 \item{dpi.ggsave}{Numeric specify dpi of the \pkg{ggsurvfit} plot.}
 
+\item{printEachVar}{Logical. If \code{TRUE}, when multiple covariates are listed
+on the right-hand side (e.g., \code{~ a + b + c}), the function produces
+a panel of CIF plots, each stratified by one variable at a time.}
+
+\item{rows.columns.panel}{Optional integer vector \code{c(nrow, ncol)} controlling
+the panel layout. If \code{NULL}, an automatic layout is used.}
+
+\item{order.strata}{Optional \code{list} to control the display order of strata levels
+when \code{printEachVar = TRUE}. Supply as \code{list(var = c("L1","L2",...))}.
+Levels not listed are dropped. Must be consistent with \code{label.strata}:
+if \code{label.strata[[var]]} is a named character vector, names are matched to
+levels; otherwise labels are matched by position and must have the same length as
+the (possibly re-ordered) levels.}
+
 \item{...}{Additional arguments forwarded to \code{cifpanel()} when \code{printBoth = TRUE}.}
 }
 \value{
-A \code{ggplot} object.
+A \code{ggplot} object. When \code{printEachVar = TRUE}, a \pkg{patchwork}
+object is returned with an attribute \code{attr(x, "plots")} containing the
+individual \code{ggplot} panels.
 }
 \description{
 This function produces the Kaplan–Meier survival or Aalen–Johansen cumulative

--- a/tests/testthat/test-cifplot-printEachVar.R
+++ b/tests/testthat/test-cifplot-printEachVar.R
@@ -1,0 +1,61 @@
+test_that("printEachVar returns one plot per RHS var", {
+  data(diabetes.complications)
+  plt <- cifplot(
+    Event(t, epsilon) ~ sex + fruitq1,
+    data = diabetes.complications,
+    outcome.type = "COMPETING-RISK",
+    code.event1 = 1, code.event2 = 2, code.censoring = 0,
+    printEachVar = TRUE,
+    rows.columns.panel = c(1, 2)
+  )
+  expect_true(inherits(plt, "patchwork") || inherits(plt, "ggplot"))
+  pa <- attr(plt, "plots")
+  expect_false(is.null(pa))
+  expect_length(pa, 2L)
+  expect_true(all(vapply(pa, function(p) inherits(p, "ggplot"), logical(1))))
+})
+
+test_that("order.strata and label.strata (positional) are respected", {
+  data(diabetes.complications)
+  plt <- cifplot(
+    Event(t, epsilon) ~ fruitq1,
+    data = diabetes.complications,
+    outcome.type = "COMPETING-RISK",
+    code.event1 = 1, code.event2 = 2, code.censoring = 0,
+    printEachVar = TRUE,
+    rows.columns.panel = c(1, 1),
+    order.strata = list(fruitq1 = c("Low", "High")),
+    label.strata = list(fruitq1 = c("Low intake", "High"))
+  )
+  expect_true(inherits(plt, "patchwork") || inherits(plt, "ggplot"))
+})
+
+test_that("label.strata named mapping works with order.strata", {
+  data(diabetes.complications)
+  plt <- cifplot(
+    Event(t, epsilon) ~ fruitq1,
+    data = diabetes.complications,
+    outcome.type = "COMPETING-RISK",
+    code.event1 = 1, code.event2 = 2, code.censoring = 0,
+    printEachVar = TRUE,
+    rows.columns.panel = c(1, 1),
+    order.strata = list(fruitq1 = c("Low", "High")),
+    label.strata = list(fruitq1 = c(Low = "Low intake", High = "High"))
+  )
+  expect_true(inherits(plt, "patchwork") || inherits(plt, "ggplot"))
+})
+
+test_that("numeric RHS var errors under printEachVar", {
+  data(diabetes.complications)
+  expect_error(
+    cifplot(
+      Event(t, epsilon) ~ age,
+      data = diabetes.complications,
+      outcome.type = "COMPETING-RISK",
+      code.event1 = 1, code.event2 = 2, code.censoring = 0,
+      printEachVar = TRUE
+    ),
+    "numeric.*discretize",
+    ignore.case = TRUE
+  )
+})


### PR DESCRIPTION
## Summary
- add a printEachVar panel mode to `cifplot()` and split the core implementation into a reusable helper
- document the new workflow in the README and reference documentation
- add targeted tests that cover layout handling, strata relabeling, and numeric variable validation

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb18d8cbec8324be95a808fe31b3a1