### PR TITLE
Fix stratification handling and panel outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # cifmodeling 0.4.0
 
+* Bug fixes
+  * `order.strata` is now applied via discrete scale limits so legend and fill
+    ordering remain stable, including when `printEachVar = TRUE`.
+  * Numeric stratification variables are coerced to factors when they have fewer
+    than nine unique values and are split at the median (Below/Above median)
+    when they have nine or more unique values.
+  * `cifplot(printEachEvent = TRUE)` keeps both event-specific `ggplot`
+    objects in `attr(x, "plots")` while returning the combined panel.
+  * Default y-axis labels consistently use "Survival" for survival outcomes and
+    "Cumulative incidence" phrasing for competing-risk outcomes.
+
 # cifmodeling 0.2.0
 
 3# cifmodeling 0.1.0

--- a/R/helper-cifpanel.R
+++ b/R/helper-cifpanel.R
@@ -72,9 +72,12 @@ panel_prepare <- function(
       cc  <- pair[3]
     }
 
+    norm_inputs <- cifplot_normalize_formula_data(formulas[[i]], data)
+    data_i <- norm_inputs$data
+
     args_est <- panel_drop_nulls(list(
       formula        = formulas[[i]],
-      data           = data,
+      data           = data_i,
       outcome.type   = if (!is.null(outcome.list)) outcome.list[[i]] else NULL,
       code.event1    = ce1,
       code.event2    = ce2,

--- a/tests/testthat/test-helper-normalize-strata.R
+++ b/tests/testthat/test-helper-normalize-strata.R
@@ -1,0 +1,32 @@
+test_that("numeric vectors with <9 unique values are converted to factor", {
+  x <- c(1, 2, 2, 3, NA_real_)
+  out <- cifmodeling:::cifplot_normalize_strata_var(x)
+  expect_true(is.factor(out$values))
+  expect_identical(levels(out$values), c("1", "2", "3"))
+  expect_identical(as.character(out$values[1:4]), c("1", "2", "2", "3"))
+  expect_true(is.na(out$values[5]))
+  expect_identical(out$strategy, "factor")
+})
+
+test_that("numeric vectors with >=9 unique values are split at the median", {
+  x <- 1:10
+  out <- cifmodeling:::cifplot_normalize_strata_var(x)
+  expect_true(is.factor(out$values))
+  expect_identical(levels(out$values),
+                   c(cifmodeling:::.cifplot_labels$strata$below_median,
+                     cifmodeling:::.cifplot_labels$strata$above_median))
+  med <- stats::median(x)
+  expect_true(all(out$values[x <= med] == cifmodeling:::.cifplot_labels$strata$below_median))
+  expect_true(all(out$values[x >  med] == cifmodeling:::.cifplot_labels$strata$above_median))
+  expect_identical(out$strategy, "median")
+})
+
+test_that("formula normalization converts numeric RHS strata", {
+  df <- data.frame(time = 1:10, status = c(0, 1, rep(0, 8)), z = seq_len(10))
+  fml <- Event(time, status) ~ z
+  out <- cifmodeling:::cifplot_normalize_formula_data(fml, df)
+  expect_true(is.factor(out$data$z))
+  expect_identical(levels(out$data$z),
+                   c(cifmodeling:::.cifplot_labels$strata$below_median,
+                     cifmodeling:::.cifplot_labels$strata$above_median))
+})


### PR DESCRIPTION
## Summary
- normalise numeric stratification variables so large continuous sets split at the median and smaller sets become factors
- apply `order.strata` through discrete scale limits and keep both event-specific ggplots attached when `printEachEvent = TRUE`
- centralise default axis/event labels and add unit tests and NEWS notes covering the new helper logic

## Testing
- `R -q -e "testthat::test_local()"` *(fails: R executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb9645d6ac8324b03bce57717520fc