### PR TITLE
Refactor cifplot scale application

### DIFF
--- a/R/cifplot.R
+++ b/R/cifplot.R
@@ -183,7 +183,7 @@
 #'         label.x='Years from registration')
 
 #' @importFrom ggsurvfit ggsurvfit add_confidence_interval add_risktable add_risktable_strata_symbol add_censor_mark add_quantile
-#' @importFrom ggplot2 theme_classic theme_bw element_text labs lims geom_point aes ggsave scale_color_discrete scale_fill_discrete element_text element_rect element_blank scale_color_manual scale_fill_manual scale_linetype_manual scale_shape_manual
+#' @importFrom ggplot2 theme_classic theme_bw element_text labs lims geom_point aes ggsave guides scale_color_discrete scale_fill_discrete element_text element_rect element_blank scale_color_manual scale_fill_manual scale_linetype_manual scale_shape_manual scale_linetype_discrete scale_shape_discrete
 #' @importFrom grDevices gray
 #' @importFrom patchwork wrap_plots
 
@@ -899,6 +899,8 @@ call_ggsurvfit <- function(
     p <- plot_draw_marks(p, survfit_object, intercurrent.event.time, out_cg$type.y, shape = shape.intercurrent.event.mark, size = size.intercurrent.event.mark)
   }
 
+  p <- p + ggplot2::guides(fill = "none")
+
   x_max <- plot_make_x_max(survfit_object)
   if (isTRUE(use_coord_cartesian)) {
     if (!is.null(breaks.x)) p <- p + ggplot2::scale_x_continuous(breaks = breaks.x)
@@ -943,36 +945,14 @@ call_ggsurvfit <- function(
     )
   }
 
-  if (!is.null(label.strata.map)) {
-    lvls   <- names(label.strata.map)
-    labs   <- unname(label.strata.map)
-    n      <- length(lvls)
-
-    if (identical(style, "MONOCHROME")) {
-      ltys_all   <- c("dashed","solid","dotted","longdash","dotdash","twodash",
-                      "dashed","solid","dotted","longdash","dotdash","twodash")
-      shapes_all <- c(16, 1, 3, 4, 15, 17, 16, 1, 3, 4, 15, 17)
-      ltys   <- ltys_all[seq_len(n)]
-      shps   <- shapes_all[seq_len(n)]
-      fills  <- gray(seq(0.85, 0.30, length.out = n))
-
-      p <- p +
-        ggplot2::scale_color_manual   (values = rep("black", n), limits = lvls, labels = labs) +
-        ggplot2::scale_fill_manual    (values = fills,           limits = lvls, labels = labs) +
-        ggplot2::scale_linetype_manual(values = ltys,            limits = lvls, labels = labs) +
-        ggplot2::scale_shape_manual   (values = shps,            limits = lvls, labels = labs)
-
-    } else {
-      if (is.null(palette)) {
-        p <- p +
-          ggplot2::scale_color_discrete  (limits =  lvls, labels = labs) +
-          ggplot2::scale_fill_discrete   (limits =  lvls, labels = labs) +
-          ggplot2::scale_linetype_discrete(limits = lvls, labels = labs)
-      }
-      p <- p +
-        ggplot2::scale_shape_discrete  (limits =  lvls, labels = labs)
-    }
-  }
+  p <- apply_all_scales_once(
+    p,
+    style = style,
+    palette = palette,
+    n_strata = n_strata_effective,
+    strata_levels_final = strata_levels_final,
+    strata_labels_final = strata_labels_final
+  )
 
   #  use.polyreg <- FALSE
   #  time.point.polyreg <- NULL

--- a/R/helper-cifplot.R
+++ b/R/helper-cifplot.R
@@ -150,17 +150,29 @@ plot_style_monochrome <- function(font.family = "sans", font.size = 14, legend.p
     )
 }
 
+#' Monochrome scale defaults for CIF plots
+#'
+#' @param n_strata Number of strata to generate values for.
+#'
+#' @return A named list containing vectors for color, fill, linetype, and shape.
+#' @keywords internal
 plot_scale_monochrome <- function(n_strata = 6) {
-  ltys_all   <- c("dashed","solid","dotted","longdash","dotdash","twodash",
-                  "dashed","solid","dotted","longdash","dotdash","twodash",
-                  "dashed","solid","dotted","longdash","dotdash","twodash")
-  shapes_all <- c(16, 1, 3, 4, 15, 17, 16, 1, 3, 4, 15, 17, 16, 1, 3, 4, 15, 17)
-  n_use <- min(n_strata, length(ltys_all), length(shapes_all))
+  ltys_all <- c(
+    "dashed", "solid", "dotted", "longdash", "dotdash", "twodash",
+    "dashed", "solid", "dotted", "longdash", "dotdash", "twodash",
+    "dashed", "solid", "dotted", "longdash", "dotdash", "twodash"
+  )
+  shapes_all <- c(
+    16, 1, 3, 4, 15, 17,
+    16, 1, 3, 4, 15, 17,
+    16, 1, 3, 4, 15, 17
+  )
+  n_use <- max(1, min(n_strata, length(ltys_all), length(shapes_all)))
   list(
-    ggplot2::scale_color_manual(values = rep("black", n_use), drop = FALSE, guide = "legend"),
-    ggplot2::scale_fill_manual(values = gray(seq(0.85, 0.30, length.out = n_use)), drop = FALSE, guide = "legend"),
-    ggplot2::scale_linetype_manual(values = ltys_all[seq_len(n_use)], drop = FALSE, guide = "legend"),
-    ggplot2::scale_shape_manual(values = shapes_all[seq_len(n_use)], drop = FALSE, guide = "legend")
+    color    = rep("black", n_use),
+    fill     = gray(seq(0.85, 0.30, length.out = n_use)),
+    linetype = ltys_all[seq_len(n_use)],
+    shape    = shapes_all[seq_len(n_use)]
   )
 }
 

--- a/tests/testthat/test-plot-apply-style.R
+++ b/tests/testthat/test-plot-apply-style.R
@@ -1,52 +1,142 @@
-test_that("default keeps ggsurvfit scales (no manual scales added)", {
+setup_plot_data <- function() {
   skip_if_not_installed("ggsurvfit")
   data(diabetes.complications, package = "ggsurvfit")
-  p <- cifplot(
-    Event(t, epsilon) ~ fruitq1,
-    data = diabetes.complications,
-    outcome.type = "COMPETING-RISK",
-    code.events  = c(1, 2, 0)
-  )
-  expect_true(inherits(p, c("gg", "ggplot")) || inherits(p, "patchwork"))
-  sc_col <- try(p$scales$get_scales("colour"), silent = TRUE)
-  sc_lin <- try(p$scales$get_scales("linetype"), silent = TRUE)
-  expect_true(!inherits(sc_col, "try-error"))
-  expect_true(!inherits(sc_lin, "try-error"))
-  if (!inherits(sc_col, "try-error")) {
-    expect_false(inherits(sc_col, "ScaleDiscreteManual"))
-  }
-  if (!inherits(sc_lin, "try-error")) {
-    expect_false(inherits(sc_lin, "ScaleDiscreteManual"))
-  }
-})
+  diabetes.complications
+}
 
-test_that("when all colors identical, linetype varies", {
-  skip_if_not_installed("ggsurvfit")
-  data(diabetes.complications, package = "ggsurvfit")
+test_that("label.strata only adjusts labels and suppresses fill legend", {
+  df <- setup_plot_data()
+  lbls <- c("0" = "Low intake", "1" = "High intake")
   p <- cifplot(
     Event(t, epsilon) ~ fruitq1,
-    data = diabetes.complications,
+    data = df,
     outcome.type = "COMPETING-RISK",
     code.events  = c(1, 2, 0),
-    palette = rep("red", 3)
+    label.strata = lbls,
+    addRiskTable = FALSE
   )
-  expect_true(inherits(p, c("gg", "ggplot")) || inherits(p, "patchwork"))
+
+  expect_s3_class(p, "ggplot")
+  sc_col <- p$scales$get_scales("colour")
   sc_lin <- p$scales$get_scales("linetype")
-  lts <- sc_lin$get_limits()
-  expect_gt(length(unique(lts)), 1)
+  sc_fill <- p$scales$get_scales("fill")
+  sc_shape <- p$scales$get_scales("shape")
+
+  expect_equal(sc_col$get_labels(), unname(lbls))
+  expect_equal(sc_lin$get_labels(), unname(lbls))
+  expect_identical(sc_fill$guide, "none")
+  expect_identical(sc_shape$guide, "none")
 })
 
-test_that("when colors differ, all linetypes are solid", {
-  skip_if_not_installed("ggsurvfit")
-  data(diabetes.complications, package = "ggsurvfit")
+test_that("palette only uses manual color scale", {
+  df <- setup_plot_data()
+  pal <- c("#FF0000", "#0000FF")
   p <- cifplot(
     Event(t, epsilon) ~ fruitq1,
-    data = diabetes.complications,
+    data = df,
     outcome.type = "COMPETING-RISK",
     code.events  = c(1, 2, 0),
-    palette = c("red", "blue", "green")
+    palette = pal,
+    addRiskTable = FALSE
   )
+
+  sc_col <- p$scales$get_scales("colour")
+  expect_s3_class(sc_col, "ScaleDiscreteManual")
+  expect_identical(sc_col$scale_name, "manual")
+  expect_equal(sc_col$palette(seq_along(pal)), pal)
+
+  sc_fill <- p$scales$get_scales("fill")
+  expect_identical(sc_fill$guide, "none")
+})
+
+test_that("label.strata overrides palette labels", {
+  df <- setup_plot_data()
+  pal <- c("#FF0000", "#0000FF")
+  lbls <- c("0" = "Group A", "1" = "Group B")
+  p <- cifplot(
+    Event(t, epsilon) ~ fruitq1,
+    data = df,
+    outcome.type = "COMPETING-RISK",
+    code.events  = c(1, 2, 0),
+    palette = pal,
+    label.strata = lbls,
+    addRiskTable = FALSE
+  )
+
+  sc_col <- p$scales$get_scales("colour")
+  expect_equal(sc_col$get_labels(), unname(lbls))
+  expect_equal(sc_col$palette(seq_along(pal)), pal)
+
+  sc_fill <- p$scales$get_scales("fill")
+  expect_identical(sc_fill$guide, "none")
+})
+
+test_that("MONOCHROME style forces black color and linetype scale", {
+  df <- setup_plot_data()
+  p <- cifplot(
+    Event(t, epsilon) ~ fruitq1,
+    data = df,
+    outcome.type = "COMPETING-RISK",
+    code.events  = c(1, 2, 0),
+    style = "MONOCHROME",
+    addRiskTable = FALSE
+  )
+
+  sc_col <- p$scales$get_scales("colour")
   sc_lin <- p$scales$get_scales("linetype")
-  lts <- sc_lin$get_limits()
-  expect_true(all(lts == "solid"))
+  sc_fill <- p$scales$get_scales("fill")
+
+  expect_s3_class(sc_lin, "ScaleDiscreteManual")
+  breaks <- sc_col$get_breaks()
+  n_breaks <- if (length(breaks)) length(breaks) else 1L
+  expect_equal(sc_col$palette(seq_len(n_breaks)), rep("black", n_breaks))
+  exp_fill <- grDevices::gray(seq(0.85, 0.30, length.out = n_breaks))
+  expect_equal(sc_fill$palette(seq_len(n_breaks)), exp_fill)
+  expect_identical(sc_fill$guide, "none")
+})
+
+test_that("palette is ignored when MONOCHROME style is requested", {
+  df <- setup_plot_data()
+  pal <- c("#FF0000", "#0000FF")
+  lbls <- c("0" = "Low", "1" = "High")
+  expect_warning({
+    p <- cifplot(
+      Event(t, epsilon) ~ fruitq1,
+      data = df,
+      outcome.type = "COMPETING-RISK",
+      code.events  = c(1, 2, 0),
+      palette = pal,
+      style = "MONOCHROME",
+      label.strata = lbls,
+      addRiskTable = FALSE
+    )
+  }, regexp = NA)
+
+  sc_col <- p$scales$get_scales("colour")
+  sc_lin <- p$scales$get_scales("linetype")
+
+  breaks <- sc_col$get_breaks()
+  n_breaks <- if (length(breaks)) length(breaks) else 1L
+  expect_equal(sc_col$palette(seq_len(n_breaks)), rep("black", n_breaks))
+  expect_s3_class(sc_lin, "ScaleDiscreteManual")
+  expect_equal(sc_lin$get_labels(), unname(lbls))
+})
+
+test_that("order.strata sets scale limits", {
+  df <- setup_plot_data()
+  lbls <- c("0" = "Low", "1" = "High")
+  ord <- c("1", "0")
+  p <- cifplot(
+    Event(t, epsilon) ~ fruitq1,
+    data = df,
+    outcome.type = "COMPETING-RISK",
+    code.events  = c(1, 2, 0),
+    label.strata = lbls,
+    order.strata = ord,
+    addRiskTable = FALSE
+  )
+
+  sc_col <- p$scales$get_scales("colour")
+  expect_identical(sc_col$get_limits(), ord)
+  expect_equal(sc_col$get_labels(), unname(lbls[ord]))
 })


### PR DESCRIPTION
## Summary
- centralize color/linetype/fill scale configuration in `apply_all_scales_once()` so guides, labels, and palettes follow the documented precedence
- constrain `plot_apply_style()` to theme tweaks and make monochrome scale helpers return raw values used by the shared scaler
- rewrite cifplot scale tests to cover label/palette precedence, monochrome overrides, and legend suppression

## Testing
- not run (R binary is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fc7ec04c20832497a0eaf6dbdb253d